### PR TITLE
fix: include typings in the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist/index.js",
-    "dist/index.d.js"
+    "dist/index.d.ts"
   ],
   "devDependencies": {
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
A typo results in typings not being published